### PR TITLE
feat: jazzy support

### DIFF
--- a/generic_type_utility/CMakeLists.txt
+++ b/generic_type_utility/CMakeLists.txt
@@ -23,6 +23,18 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/ros2/structure.cpp
 )
 
+# Set ROS_DISTRO macros
+set(ROS_DISTRO $ENV{ROS_DISTRO})
+if(${ROS_DISTRO} STREQUAL "rolling")
+  add_compile_definitions(ROS_DISTRO_ROLLING)
+elseif(${ROS_DISTRO} STREQUAL "galactic")
+  add_compile_definitions(ROS_DISTRO_GALACTIC)
+elseif(${ROS_DISTRO} STREQUAL "humble")
+  add_compile_definitions(ROS_DISTRO_HUMBLE)
+elseif(${ROS_DISTRO} STREQUAL "jazzy")
+  add_compile_definitions(ROS_DISTRO_JAZZY)
+endif()
+
 target_link_libraries(${PROJECT_NAME} yaml-cpp)
 
 ament_auto_add_executable(print

--- a/generic_type_utility/CMakeLists.txt
+++ b/generic_type_utility/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
+find_package(yaml-cpp REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/generic_property.cpp
@@ -21,6 +22,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/ros2/message.cpp
   src/ros2/structure.cpp
 )
+
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
 
 ament_auto_add_executable(print
   src/examples/print.cpp

--- a/generic_type_utility/CMakeLists.txt
+++ b/generic_type_utility/CMakeLists.txt
@@ -27,8 +27,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 set(ROS_DISTRO $ENV{ROS_DISTRO})
 if(${ROS_DISTRO} STREQUAL "rolling")
   add_compile_definitions(ROS_DISTRO_ROLLING)
-elseif(${ROS_DISTRO} STREQUAL "galactic")
-  add_compile_definitions(ROS_DISTRO_GALACTIC)
 elseif(${ROS_DISTRO} STREQUAL "humble")
   add_compile_definitions(ROS_DISTRO_HUMBLE)
 elseif(${ROS_DISTRO} STREQUAL "jazzy")

--- a/generic_type_utility/src/ros2/introspection.cpp
+++ b/generic_type_utility/src/ros2/introspection.cpp
@@ -33,7 +33,11 @@ RosIntrospection::Impl::Impl(const std::string & type_name)
   constexpr char identifier[] = "rosidl_typesupport_introspection_cpp";
   library_ = rclcpp::get_typesupport_library(type_name, identifier);
 
+#ifdef ROS_DISTRO_HUMBLE
+  const auto handle = rclcpp::get_typesupport_handle(type_name, identifier, *library_);
+#else
   const auto handle = rclcpp::get_message_typesupport_handle(type_name, identifier, *library_);
+#endif
   rostype_ = std::make_unique<RosTypeNode>(nullptr, handle);
 }
 

--- a/generic_type_utility/src/ros2/introspection.cpp
+++ b/generic_type_utility/src/ros2/introspection.cpp
@@ -33,7 +33,7 @@ RosIntrospection::Impl::Impl(const std::string & type_name)
   constexpr char identifier[] = "rosidl_typesupport_introspection_cpp";
   library_ = rclcpp::get_typesupport_library(type_name, identifier);
 
-  const auto handle = rclcpp::get_typesupport_handle(type_name, identifier, *library_);
+  const auto handle = rclcpp::get_message_typesupport_handle(type_name, identifier, *library_);
   rostype_ = std::make_unique<RosTypeNode>(nullptr, handle);
 }
 

--- a/generic_type_utility/src/ros2/serialization.cpp
+++ b/generic_type_utility/src/ros2/serialization.cpp
@@ -33,7 +33,11 @@ RosSerialization::Impl::Impl(const std::string & type_name)
   constexpr char identifier[] = "rosidl_typesupport_cpp";
   library_ = rclcpp::get_typesupport_library(type_name, identifier);
 
+#ifdef ROS_DISTRO_HUMBLE
+  const auto handle = rclcpp::get_typesupport_handle(type_name, identifier, *library_);
+#else
   const auto handle = rclcpp::get_message_typesupport_handle(type_name, identifier, *library_);
+#endif
   serialization_ = std::make_unique<rclcpp::SerializationBase>(handle);
 }
 

--- a/generic_type_utility/src/ros2/serialization.cpp
+++ b/generic_type_utility/src/ros2/serialization.cpp
@@ -33,7 +33,7 @@ RosSerialization::Impl::Impl(const std::string & type_name)
   constexpr char identifier[] = "rosidl_typesupport_cpp";
   library_ = rclcpp::get_typesupport_library(type_name, identifier);
 
-  const auto handle = rclcpp::get_typesupport_handle(type_name, identifier, *library_);
+  const auto handle = rclcpp::get_message_typesupport_handle(type_name, identifier, *library_);
   serialization_ = std::make_unique<rclcpp::SerializationBase>(handle);
 }
 


### PR DESCRIPTION
## Description

This pull request adds ROS 2 Jazzy compatibility while keeping Humble behavior unchanged. 

* In Jazzy, `rclcpp::get_typesupport_handle` is deprecated. The code now selects the correct call at compile time using `ROS_DISTRO_*` preprocessor macros set from the `ROS_DISTRO` environment variable in CMake.
* Declare `yaml-cpp` with `find_package` and link it to the library target (required for the Jazzy)


> [TIER IV INTERNAL ticket](https://tier4.atlassian.net/browse/T4DEV-49321)

### Related links

* `get_typesupport_handle` is depricated.
https://docs.ros.org/en/jazzy/p/rclcpp/generated/function_namespacerclcpp_1a7e62562624ffa7c85726ea54a268fa07.html

* https://github.com/tier4/multi_data_monitor/pull/18

## How was this PR tested

### Humble build test :heavy_check_mark: 

```shell
mkdir generic_type_ws/src -p
cd generic_type_ws/src
git clone git@github.com:tier4/generic_type_utility.git -b tmp/jazzy_tmp
cd ..
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

```

### Jazzy build test :heavy_check_mark: 

```shell
mkdir generic_type_ws/src -p
cd generic_type_ws/src
git clone git@github.com:tier4/generic_type_utility.git -b tmp/jazzy_tmp
cd ..

docker run -it --rm -v $(pwd):/ros2_ws -w /ros2_ws ros:jazzy
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
```